### PR TITLE
fix code to solve the precision issue

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -166,6 +166,7 @@ func ParseCoin(coinStr string) (coin store.Coin) {
 	}
 	denom, amount := matches[2], matches[1]
 
+	amount = getPrecision(amount, denom)
 	amt, err := strconv.ParseFloat(amount, 64)
 	if err != nil {
 		logger.Error("Convert str to int failed", logger.Any("amount", amount))
@@ -176,6 +177,13 @@ func ParseCoin(coinStr string) (coin store.Coin) {
 		Denom:  denom,
 		Amount: amt,
 	}
+}
+
+func getPrecision(amount, denom string) string {
+	if denom == types.NativeTokenMinDenom && len(amount) > 16 {
+		amount = string([]byte(amount)[:16]) + "00"
+	}
+	return amount
 }
 
 func BuildFee(fee auth.StdFee) store.Fee {

--- a/types/types.go
+++ b/types/types.go
@@ -180,8 +180,12 @@ func ParseCoin(coinStr string) (coin store.Coin) {
 }
 
 func getPrecision(amount, denom string) string {
-	if denom == types.NativeTokenMinDenom && len(amount) > 16 {
-		amount = string([]byte(amount)[:16]) + "00"
+	length := len(amount)
+	if denom == types.NativeTokenMinDenom && length > 15 {
+		amount = string([]byte(amount)[:15])
+		for i := 1; i <= length-15; i++ {
+			amount += "0"
+		}
 	}
 	return amount
 }


### PR DESCRIPTION
为了避免四舍五入导致精度丢失，同步交易记录解析时，iris-atto单位只保留前15位数值,之后的数据补零